### PR TITLE
docs: require Conventional Commits with user value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,5 +11,9 @@ All agents must follow these rules:
 5) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
 6) Maximize the use of caching in GitHub workflow files to minimize run duration.
 7) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
+8) PR descriptions must include Summary, Rationale, and Details sections.
+9) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
+10) Update dependency lockfiles when adding or removing Python dependencies.
+11) When adding or refactoring async RPC/price-fetching code, keep or add `y._decorators.stuck_coro_debugger` so the `y.stuck?` DEBUG logger continues emitting "still executing" messages at the default 5-minute interval (via `a_sync.debugging.stuck_coro_debugger`).
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,5 +10,6 @@ All agents must follow these rules:
 4) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 5) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
 6) Maximize the use of caching in GitHub workflow files to minimize run duration.
+7) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary
- Add commit message guidance to `AGENTS.md` that requires Conventional Commits prefixes and user-value callouts.

Rationale
- Consistent commit messages make history easier to scan and improve user-facing release notes.

Details
- Add the rule requiring Conventional Commits prefixes plus a short functional description and user-facing value proposition.