### PR TITLE
chore(cicd): add commitlint checks for conventional commits

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,16 @@
+name: Commitlint
+
+on:
+  pull_request:
+
+jobs:
+  commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v2

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ["@commitlint/config-conventional"]};


### PR DESCRIPTION
## Summary
- add commitlint configuration
- add a commitlint workflow for pull requests

## Rationale
Enforcing Conventional Commits helps ensure commit messages include a clear functional description and expected user-facing value.

## Details
- `commitlint.config.js` uses the conventional config
- the workflow runs commitlint on PR commits with full history